### PR TITLE
cytoolz 0.12.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,17 @@
-{% set version = "0.11.0" %}
+{% set name = "cytoolz" %}
+{% set version = "0.12.0" %}
 
 package:
-  name: cytoolz
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/c/cytoolz/cytoolz-{{ version }}.tar.gz
-  sha256: c64f3590c3eb40e1548f0d3c6b2ccde70493d0b8dc6cc7f9f3fec0bb3dcd4222
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/cytoolz-{{ version }}.tar.gz
+  sha256: c105b05f85e03fbcd60244375968e62e44fe798c15a3531c922d531018d22412
 
 build:
   number: 0
+  skip: True  # [py<35]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv --global-option=--with-cython
 
 requirements:
@@ -19,24 +21,31 @@ requirements:
     - python
     - cython
     - pip
+    - setuptools
+    - wheel
   run:
     - python
+    # Require toolz >=0.10.0, see https://github.com/conda-forge/cytoolz-feedstock/commit/81ab3dd10a4f60b81cf5dd91165d4faf55f3a73a
     - toolz >=0.10.0
 
 test:
-  requires:
-    - nose
-    - toolz 0.10.0
   imports:
     - cytoolz
     - cytoolz.curried
+  requires:
+    - pip
+    - pytest
+    - toolz
   commands:
-    - nosetests --with-doctest cytoolz
+    - pip check
+    - pytest -v --doctest-modules --pyargs cytoolz
 
 about:
   home: https://github.com/pytoolz/cytoolz
   license: BSD-3-Clause
+  lisense_family: BSD
   license_file: LICENSE.txt
+  license_url: https://github.com/pytoolz/cytoolz/blob/master/LICENSE.txt
   summary: Cython implementation of Toolz. High performance functional utilities
   description: |
     CyToolz is the Cython implementation of the toolz package, which provides

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,9 +43,9 @@ test:
     - pip check
     - pytest -v --doctest-modules --pyargs cytoolz
     # Make sure we can cimport cytoolz
-    - echo 'cimport cytoolz ; from cytoolz.functoolz cimport memoize' > try_cimport_cytoolz.pyx
-    - cythonize -i try_cimport_cytoolz.pyx
-    - python -c 'import try_cimport_cytoolz'
+    - echo 'cimport cytoolz ; from cytoolz.functoolz cimport memoize' > try_cimport_cytoolz.pyx  # [not win]
+    - cythonize -i try_cimport_cytoolz.pyx    # [not win]
+    - python -c 'import try_cimport_cytoolz'  # [not win]
 
 about:
   home: https://github.com/pytoolz/cytoolz

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,7 @@ about:
     CyToolz is the Cython implementation of the toolz package, which provides
     high performance utility functions for iterables, functions, and
     dictionaries.
-  doc_url: https://pypi.python.org/pypi/cytoolz
+  doc_url: https://pypi.org/project/cytoolz/
   doc_source_url: https://github.com/pytoolz/cytoolz/blob/master/README.rst
   dev_url: https://github.com/pytoolz/cytoolz
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ test:
 about:
   home: https://github.com/pytoolz/cytoolz
   license: BSD-3-Clause
-  lisense_family: BSD
+  license_family: BSD
   license_file: LICENSE.txt
   license_url: https://github.com/pytoolz/cytoolz/blob/master/LICENSE.txt
   summary: Cython implementation of Toolz. High performance functional utilities

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,8 @@ test:
     - cytoolz
     - cytoolz.curried
   requires:
-    # To run the 'cyntonize' command
+    # Require gcc and cython to run the 'cyntonize' command
+    - {{ compiler('c') }}
     - cython
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,12 +33,18 @@ test:
     - cytoolz
     - cytoolz.curried
   requires:
+    # To run the 'cyntonize' command
+    - cython
     - pip
     - pytest
     - toolz
   commands:
     - pip check
     - pytest -v --doctest-modules --pyargs cytoolz
+    # Make sure we can cimport cytoolz
+    - echo 'cimport cytoolz ; from cytoolz.functoolz cimport memoize' > try_cimport_cytoolz.pyx
+    - cythonize -i try_cimport_cytoolz.pyx
+    - python -c 'import try_cimport_cytoolz'
 
 about:
   home: https://github.com/pytoolz/cytoolz


### PR DESCRIPTION
**Jira ticket:** [PKG-127](https://anaconda.atlassian.net/browse/PKG-127) (cytoolz-0.12.0)

**The upstream data:**
Github releases:  https://github.com/pytoolz/cytoolz/releases
[Diff between the latest and previous upstream releases](https://github.com/pytoolz/cytoolz/compare/0.11.0...0.12.0)
Requirements:
 * setup.cfg:  https://github.com/pytoolz/cytoolz/blob/0.12.0/setup.cfg
 * setup.py:  https://github.com/pytoolz/cytoolz/blob/0.12.0/setup.py
 * pyproject.toml:  https://github.com/pytoolz/cytoolz/blob/0.12.0/pyproject.toml

**_Actions:_**

1. Add jinja2 templates
2. Skip `py<35`
3. Add missing `setuptools` and `wheel` to `host`
4. Add a comment about the usage of `toolz >=0.10.0`
5. Update `test/requires`: add `C compiler` an `cython` to test the `cyntonize` command
6. Add `pip check`
7. Add the `pytest` command
8. Add the `cyntonize` command on `unix`, see https://github.com/pytoolz/cytoolz/blob/812a1ab8fb64109f5cb185cc2f1d39dab8e196fc/.github/workflows/test.yml#L48-L51
9. Add `license_family`
10. Add `license_url`

**_Notes:_**
 * It's a `conda` **run_constrained** dependency, see https://github.com/AnacondaRecipes/conda-feedstock/blob/92ac6eed450ce4ef3ce5585dc13a9c2a9b9ecc06/recipe/meta.yaml#L60

**Package's statistics**
<details>

 * Priority C | effort: easy | Category: anaconda | subcategory: core | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 0.12.0
 * Release on PyPi:
    * version: 0.12.0
    * date: 2022-07-11T03:02:04
* [PyPi history](https://pypi.org/project/cytoolz/#history)
 * Popularity: 
    * 3 months downloads: 1074574.0
    * All time:  7796482 downloads -  cytoolz  0.12.0  Cython implementation of Toolz. High performance functional utilities  

</details>

**Links:**
<details>

* [The v0.12.0 upstream URL](https://github.com/pytoolz/cytoolz/tree/0.12.0)
* [dev_url](https://github.com/pytoolz/cytoolz)
* [doc_url](https://github.com/pytoolz/cytoolz)
* [Bug tracker](https://github.com/pytoolz/cytoolz/issues)
* [PyPi](https://pypi.org/project/cytoolz)
* [conda-forge recipe](https://github.com/conda-forge/cytoolz-feedstock/blob/master/recipe/meta.yaml)
* [Anaconda recipe feedstock](https://github.com/AnacondaRecipes/cytoolz-feedstock)
* [Update branch: _0.12.0_](https://github.com/AnacondaRecipes/cytoolz-feedstock/tree/0.12.0)
* [Diff between upstream conda-forge **main** and aggregate **feature** branch](https://github.com/conda-forge/cytoolz-feedstock/compare/main...AnacondaRecipes:0.12.0#files_bucket)
* [Diff between origin aggregate **master** and aggregate **feature** branch](https://github.com/AnacondaRecipes/cytoolz-feedstock/compare/master...AnacondaRecipes:0.12.0#files_bucket)
* [The last merged PRs](https://github.com/AnacondaRecipes/cytoolz-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

</details>

**Anaconda Linter:**

<details>

The following problems have been found:

ERROR: /aggregate/cytoolz-feedstock/recipe/meta.yaml:22: missing_wheel: For pypi packages, wheel should be present in the host section
ERROR: /aggregate/cytoolz-feedstock/recipe/meta.yaml:35: missing_pip_check: For pypi packages, pip check should be present in the test commands
ERROR: /aggregate/cytoolz-feedstock/recipe/meta.yaml:46: invalid_url: https://pypi.python.org/pypi/cytoolz : URL domain redirect pypi.python.org ->  pypi.org
ERROR: /aggregate/cytoolz-feedstock/recipe/meta.yaml:48: missing_license_family: The recipe is missing the `about/license_family` key.
WARNING: /aggregate/cytoolz-feedstock/recipe/meta.yaml:48: missing_license_url: The recipe is missing a license_url
Errors were found

</details>

**Crender checks:**

<details>
0.11.0:
- Missing wheel package in requirements
- Missing setuptools package in requirements
- No license family specified

</details>


**Other checks:**

<details>

1. - [x] https://github.com/pytoolz/cytoolz/tree/0.12.0 exists
11. - [x] https://github.com/pytoolz/cytoolz is present
12. - [x] Check the pinnings
13. - [x] Additional research
    https://github.com/conda-forge/cytoolz-feedstock/issues
    200
14. - [x] `dev_url` is present
    https://github.com/pytoolz/cytoolz
15. - [x] `doc_url`:
    https://pypi.python.org/pypi/cytoolz
16. - [x] `doc_source_url` is present
    https://github.com/pytoolz/cytoolz/blob/master/README.rst
17. - [x] Verify that the `build_number` is correct
18. - [x] Verify if the package needs `setuptools`
19. - [x] Verify if the package needs `wheel`
20. - [x] `pip` in test
21. - [x] Verify the test section
22. - [x] Verify if the package is `architecture specific`
23. - [x] Verify that private module are not mentioned on the recipe For example: (_private_module)
24.  - [x] license_file: LICENSE.txt is present
25. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |

26. - [x] License family is present
    
</details>


**Updating the recipe:**

If the recipe needs additional modification the update branch can be modified.

```
git clone -b 0.12.0 git@github.com:AnacondaRecipes/cytoolz-feedstock.git
```

